### PR TITLE
Fix admin role name in security config

### DIFF
--- a/src/main/java/com/dualstore/tienda/config/SecurityConfig.java
+++ b/src/main/java/com/dualstore/tienda/config/SecurityConfig.java
@@ -19,7 +19,9 @@ public class SecurityConfig {
         return http
             .securityMatcher("/admin/**", "/dashboard", "/productos/**", "/categorias/**", "/unidadmedida/**", "/usuarios/**", "/roles/**", "/css/**", "/js/**", "/img/**", "/fragments/**")            .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/admin/login", "/admin/css/**", "/admin/js/**", "/admin/img/**", "/css/**", "/js/**", "/img/**", "/fragments/**").permitAll()
-                .anyRequest().hasRole("ADMIN")
+                // Se admite tanto ADMIN como ADMINISTRADOR para evitar errores
+                // cuando el nombre del rol en la base de datos difiere
+                .anyRequest().hasAnyRole("ADMIN", "ADMINISTRADOR")
             )
             .formLogin(form -> form
                 .loginPage("/admin/login")


### PR DESCRIPTION
## Summary
- support `ADMINISTRADOR` role in admin filter chain so admin dashboard loads

## Testing
- `./mvnw -q test` *(fails: could not fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_68498bb450ac8322bc7b28ab8160dd14